### PR TITLE
Add reusable Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,43 @@
+name: Claude Code Review
+
+on:
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          # No --model specified: uses Claude Code's default (currently Opus 4.6)
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary
- Adds a centralized, reusable Claude Code Review workflow that all ShakaCode repos can call
- No `--model` flag specified — uses Claude Code's default model (currently Opus 4.6), so reviews automatically upgrade when Anthropic ships newer models
- Repos call this with just a few lines instead of duplicating the full config

## Repos to migrate
After merging, these repos need their `claude-code-review.yml` updated to call this reusable workflow:
- `react_on_rails` (PR already open)
- `hichee`
- `react-webpack-rails-tutorial`
- `shakapacker`
- `react_on_rails-demos`

## Usage
Each repo's `.github/workflows/claude-code-review.yml` becomes:
```yaml
name: Claude Code Review

on:
  pull_request:
    types: [opened, synchronize]

jobs:
  claude-review:
    uses: shakacode/.github/.github/workflows/claude-code-review.yml@main
    secrets:
      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated automated code review system that analyzes pull requests and provides comprehensive feedback on code quality, potential issues, performance considerations, security vulnerabilities, and test coverage. Feedback is automatically posted as PR comments for streamlined developer workflow and actionable improvement suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->