### PR TITLE
Add repo-file-sync-action to auto-sync Claude workflows

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,54 @@
+group:
+  # Repos with both claude.yml and claude-code-review.yml
+  - files:
+      - source: .github/workflows/claude-code-review.yml
+        dest: .github/workflows/claude-code-review.yml
+      - source: .github/workflows/claude.yml
+        dest: .github/workflows/claude.yml
+    repos: |
+      shakacode/claude-code-commands-skills-agents
+      shakacode/control-plane-flow
+      shakacode/cypress-playwright-on-rails
+      shakacode/hichee
+      shakacode/hichee-data
+      shakacode/messagebus
+      shakacode/package_json
+      shakacode/rails-v8-kamal-v2-terraform-gcp-tutorial
+      shakacode/react-webpack-rails-tutorial
+      shakacode/react_on_rails
+      shakacode/react_on_rails-demos
+      shakacode/react_on_rails_pro_licensing
+      shakacode/sc-website
+      shakacode/shakaflow
+      shakacode/shakapacker
+      shakacode/uber_task
+
+  # Repos with only claude-code-review.yml
+  - files:
+      - source: .github/workflows/claude-code-review.yml
+        dest: .github/workflows/claude-code-review.yml
+    repos: |
+      shakacode/Significance-Hypothesis-Based-ARC-AGI-2-puzzle-solver
+      shakacode/alternatives
+      shakacode/bootstrap-loader
+      shakacode/coding-agent-utils
+      shakacode/comfortable-media-surfer
+      shakacode/gumroad
+      shakacode/onnxruntime-rs
+      shakacode/petition_code_quality_and_ai
+      shakacode/rails-v8-cpln-flow-terraform-tutorial
+      shakacode/react-ppr-from-scratch
+      shakacode/react-server-components-marketplace-demo
+      shakacode/react_on_rails-demo-v16-ssr-auto-registration-bundle-splitting
+      shakacode/react_on_rails-v16-generator-playground
+      shakacode/react_on_rails_demo_ssr_hmr
+      shakacode/react_on_rails_pro
+      shakacode/react_on_rails_rsc
+      shakacode/rescript-classnames
+      shakacode/rescript-dnd
+      shakacode/rescript-debounce
+      shakacode/rescript-react-on-rails
+      shakacode/sass-resources-loader
+      shakacode/shakaperf
+      shakacode/spike-react-on-rails-tutorial-v15-with-rspack
+      shakacode/steward

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -1,0 +1,18 @@
+name: Sync Claude Workflows
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/claude-code-review.yml'
+      - '.github/workflows/claude.yml'
+  workflow_dispatch: # allow manual trigger
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: BetaHuhn/repo-file-sync-action@v1
+        with:
+          GH_PAT: ${{ secrets.GH_PAT_WORKFLOW_SYNC }}


### PR DESCRIPTION
## Summary

- Adds `BetaHuhn/repo-file-sync-action` workflow that triggers when `claude.yml` or `claude-code-review.yml` are updated on `main`
- Adds `.github/sync.yml` config listing all 40 org repos that currently use Claude workflows
- Splits repos into two groups: 16 repos with both workflow files, 24 repos with only the review workflow

## Setup required

An org-level secret `GH_PAT_WORKFLOW_SYNC` is needed — a GitHub PAT with `repo` and `workflow` scopes that has write access to all target repos.

## How it works

When either Claude workflow file is pushed to `main`, the sync action opens PRs in every listed target repo with the updated files. Can also be triggered manually via `workflow_dispatch`.

## Test plan

- [ ] Create `GH_PAT_WORKFLOW_SYNC` org secret
- [ ] Merge this PR, then make a trivial change to a Claude workflow file to verify sync PRs are created
- [ ] Verify PRs are opened only in the correct repos with the correct files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated workflow synchronization across repositories to maintain consistency in CI/CD configurations.
  * Configured repository groupings based on workflow configuration presence for streamlined workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->